### PR TITLE
FIX: editable install by setting version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='pycasbin-learning',
-    version='',
+    version='0.0.1',
     packages=[''],
     url='',
     license='',


### PR DESCRIPTION
This PR fixes editable installation by setting version string explicitly
in `setup.py`.

Closes #1 